### PR TITLE
Use a newer version of Recast so source maps are generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -33,28 +33,28 @@ $ node
 Without arguments:
 
 ```js
-> compile('$(() => main());');
+> compile('$(() => main());').code;
 '$(function() { return main(); });'
 ```
 
 With a single argument:
 
 ```js
-> compile('[1, 2, 3].map(n => n * 2);');
+> compile('[1, 2, 3].map(n => n * 2);').code;
 '[1, 2, 3].map(function(n) { return n * 2; });'
 ```
 
 With multiple arguments:
 
 ```js
-> compile('[1, 2, 3].map((n, i) => n * i);');
+> compile('[1, 2, 3].map((n, i) => n * i);').code;
 '[1, 2, 3].map(function(n, i) { return n * i; });'
 ```
 
 It binds the current context:
 
 ```js
-> compile('stream.on("data", d => this.data += d);');
+> compile('stream.on("data", d => this.data += d);').code;
 'stream.on("data", (function(d) { return this.data += d; }).bind(this));'
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,12 +84,17 @@ function transform(ast) {
  * @param {string} source
  * @return {string}
  */
-function compile(source) {
+function compile(source, mapOptions) {
+  mapOptions = mapOptions || {};
+
   var recastOptions = {
     tabWidth: guessTabWidth(source),
     // Use the harmony branch of Esprima that installs with regenerator
     // instead of the master branch that recast provides.
-    esprima: esprimaHarmony
+    esprima: esprimaHarmony,
+
+    sourceFileName: mapOptions.sourceFileName,
+    sourceMapName: mapOptions.sourceMapName
   };
 
   var ast = recast.parse(source, recastOptions);
@@ -102,7 +107,7 @@ module.exports = function () {
 
   function write (buf) { data += buf }
   function end () {
-      this.queue(require('../').compile(data));
+      this.queue(require('../').compile(data).code);
       this.queue(null);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es6-arrow-function",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Shorthand arrow functions compiled to ES5.",
   "main": "lib/index.js",
   "bin": "bin/es6-arrow-function",
@@ -14,7 +14,7 @@
   "dependencies": {
     "esprima": "git://github.com/ariya/esprima.git#harmony",
     "ast-types": "~0.3.10",
-    "recast": "~0.4.24",
+    "recast": "~0.5.12",
     "through": "~2.3.4"
   },
   "devDependencies": {

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -10,7 +10,7 @@ var recastOptions = {
 };
 
 function normalize(source) {
-  return recast.prettyPrint(recast.parse(source, recastOptions), recastOptions);
+  return recast.prettyPrint(recast.parse(source, recastOptions), recastOptions).code;
 }
 
 expect.Assertion.prototype.compileTo = function(expected) {


### PR DESCRIPTION
With this change, Recast's built-in source map support can be used. It has the side-effect of a breaking API change, since `compile` now outputs a hash of `{ code, map }`, so I went ahead and bumped the version.
