### PR TITLE
Modify node in place, rather than creating a replacement

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,18 +25,18 @@ function visitNode(node) {
     return;
   }
 
-  var body;
-
-  if (n.BlockStatement.check(node.body)) {
-    body = node.body;
-  } else {
-    body = b.blockStatement([b.returnStatement(node.body)]);
+  if (!n.BlockStatement.check(node.body)) {
+    node.body = b.blockStatement([b.returnStatement(node.body)]);
   }
 
-  var replacement = b.functionExpression(null, node.params, body);
+  // In the future, ArrowFunctionExpression and FunctionExpression nodes
+  // may get new fields (like .async) that we can't anticipate yet, so we
+  // simply switch the type and let all the other fields carry over.
+  node.type = 'FunctionExpression';
+
   var foundThisExpression = false;
 
-  types.traverse(node, function(child) {
+  types.traverse(node.body, function(child) {
     // don't look inside non-arrow functions
     if (n.Function.check(child) && !n.ArrowFunctionExpression.check(child)) {
       return false;
@@ -49,13 +49,11 @@ function visitNode(node) {
   });
 
   if (foundThisExpression) {
-    replacement = b.callExpression(
-      b.memberExpression(replacement, b.identifier('bind'), false),
+    this.replace(b.callExpression(
+      b.memberExpression(node, b.identifier('bind'), false),
       [b.thisExpression()]
-    );
+    ));
   }
-
-  this.replace(transform(replacement));
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ function visitNode(node) {
 
   types.traverse(node, function(child) {
     // don't look inside non-arrow functions
-    if (n.FunctionExpression.check(child)) {
+    if (n.Function.check(child) && !n.ArrowFunctionExpression.check(child)) {
       return false;
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,8 @@ function visitNode(node) {
     return;
   }
 
-  if (!n.BlockStatement.check(node.body)) {
+  if (node.expression) {
+    node.expression = false;
     node.body = b.blockStatement([b.returnStatement(node.body)]);
   }
 


### PR DESCRIPTION
The main benefit here is that we can just switch `node.type` to `'FunctionExpression'` and not worry about replicating its other properties, since `FunctionExpression` and `ArrowFunctionExpression` have the same fields.

In particular, I'm anticipating that `Function` nodes will eventually support an `.async` property, and I would like that to get carried over no matter what version of `ast-types` is used.
