### PR TITLE
PERF: Avoid visiting identifiers outside arrow functions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,11 @@ var util = require('ast-util');
  */
 function ArrowFunctionExpressionVisitor() {
   PathVisitor.call(this);
+
+  // In order to optimize the visitor we use a specific one for parsing the
+  // the body of the arrow function. This way very common types like Identifier
+  // are only visited under the subtree we're interested in.
+  this.bodyVisitor = new BodyVisitor(this);
 }
 ArrowFunctionExpressionVisitor.prototype = Object.create(PathVisitor.prototype);
 ArrowFunctionExpressionVisitor.prototype.constructor = ArrowFunctionExpressionVisitor;
@@ -30,7 +35,8 @@ ArrowFunctionExpressionVisitor.prototype.constructor = ArrowFunctionExpressionVi
  * @return {?Node}
  */
 ArrowFunctionExpressionVisitor.prototype.visitArrowFunctionExpression = function(path) {
-  this.traverse(path);
+  // Descend into the body using a specific visitor
+  this.traverse(path, this.bodyVisitor);
 
   var node = path.node;
   var hasThisExpression = ThisExpressionVisitor.hasThisExpression(node);
@@ -54,12 +60,28 @@ ArrowFunctionExpressionVisitor.prototype.visitArrowFunctionExpression = function
 };
 
 /**
+ * Visits the body of an arrow function expressions.
+ *
+ * @constructor
+ * @private
+ * @extends PathVisitor
+ */
+function BodyVisitor(parent) {
+  // Support nested arrow function expressions by delegating on the parent visitor
+  this.visitArrowFunctionExpression = parent.visitArrowFunctionExpression;
+
+  PathVisitor.call(this);
+}
+BodyVisitor.prototype = Object.create(PathVisitor.prototype);
+BodyVisitor.prototype.constructor = BodyVisitor;
+
+/**
  * Ensures that `arguments` directly contained in arrow functions is hoisted.
  *
  * @param {types.NodePath} path
  * @return {?Node}
  */
-ArrowFunctionExpressionVisitor.prototype.visitIdentifier = function(path) {
+BodyVisitor.prototype.visitIdentifier = function(path) {
   var node = path.node;
 
   if (node.name === 'arguments' && util.isReference(path)) {
@@ -69,7 +91,7 @@ ArrowFunctionExpressionVisitor.prototype.visitIdentifier = function(path) {
     }
   }
 
-  this.traverse(path);
+  return false;  // nothing else to look at here
 };
 
 /**
@@ -77,7 +99,7 @@ ArrowFunctionExpressionVisitor.prototype.visitIdentifier = function(path) {
  * @param {types.NodePath} path
  * @return {?types.Scope} The nearest non-arrow function scope above `path`.
  */
-ArrowFunctionExpressionVisitor.prototype.associatedFunctionScope = function(path) {
+BodyVisitor.prototype.associatedFunctionScope = function(path) {
   var scope = path.scope;
   while (scope && n.ArrowFunctionExpression.check(scope.path.node)) {
     scope = scope.parent;


### PR DESCRIPTION
Identifiers must be visited to handle `arguments` but since they are so common the visitor is being called to do nothing most of the time. This change moves the visiting logic for the body of an arrow function to a separate visitor, allowing the traversal to skip the call when it's not needed.

The results I'm getting are roughly **a x10 speed increase** when parsing things like underscore or jQuery:

```
Benchmarking...
current x 24.79 ops/sec ±1.71% (46 runs sampled)
0.6.2 x 1.91 ops/sec ±8.78% (9 runs sampled) 
```

Following this logic, perhaps there is even more room for optimization by inlining the detection of `this` using a delegated visitor. However I don't think that'll make a huge difference and the code would become harder to understand.
